### PR TITLE
Tutorial deleted as well as associated videos 

### DIFF
--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,5 +1,6 @@
 class Tutorial < ApplicationRecord
-  has_many :videos, -> { order(position: :ASC) }, inverse_of: :tutorial
+  has_many :videos, -> { order(position: :ASC) }, inverse_of: :tutorial,
+                                                  dependent: :destroy
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 end

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -11,7 +11,7 @@
     <th>Actions</th>
   </tr>
   <% @facade.tutorials.each do |tutorial| %>
-    <tr class="admin-tutorial-card">
+    <tr class="admin-tutorial-card" id="tutorial-<%= tutorial.id %>">
       <td><%= link_to tutorial.title, tutorial_path(tutorial) %></td>
       <td>
         <%= link_to "Edit", edit_admin_tutorial_path(tutorial) %> |

--- a/spec/features/admin/admin_can_delete_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_delete_tutorial_spec.rb
@@ -30,5 +30,20 @@ feature "An admin can delete a tutorial" do
 
     expect(Video.where(tutorial_id: tutorial_1.id).count).to eql(5)
     expect(Video.where(tutorial_id: tutorial_2.id).count).to eql(2)
+
+    visit "/admin/dashboard"
+
+    within("#tutorial-#{tutorial_1.id}") do
+      click_link "Delete"
+    end
+
+    expect(page).to_not have_content("#{tutorial_1.id}")
+    expect(page).to_not have_content("#{tutorial_2.id}")
+
+    expect(Video.where(tutorial_id: tutorial_1.id).empty?).to eql(true)
+    expect(Video.where(tutorial_id: tutorial_2.id).empty?).to eql(false)
+
+    expect(Video.where(tutorial_id: tutorial_2.id).count).to eql(2)
+    expect(Video.where(tutorial_id: tutorial_1.id).count).to eql(0)
   end
 end

--- a/spec/features/admin/admin_can_delete_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_delete_tutorial_spec.rb
@@ -1,11 +1,14 @@
 require 'rails_helper'
 
 feature "An admin can delete a tutorial" do
-  scenario "and it should no longer exist" do
+  before(:each) do
     admin = create(:admin)
-    create_list(:tutorial, 2)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+  end
+
+  it "deleting tutorial" do
+    create_list(:tutorial, 2)
 
     visit "/admin/dashboard"
 
@@ -16,5 +19,16 @@ feature "An admin can delete a tutorial" do
     end
 
     expect(page).to have_css('.admin-tutorial-card', count: 1)
+  end
+
+  it "video associated to tutorial is also deleted" do
+    tutorial_1 = create(:tutorial)
+    create_list(:video, 5, tutorial: tutorial_1)
+
+    tutorial_2 = create(:tutorial)
+    create_list(:video, 2, tutorial: tutorial_2)
+
+    expect(Video.where(tutorial_id: tutorial_1.id).count).to eql(5)
+    expect(Video.where(tutorial_id: tutorial_2.id).count).to eql(2)
   end
 end


### PR DESCRIPTION
## All Submissions:

* [x] Merge the target branch into the PR branch. Fix any conflicts that might appear.

### New Feature Submissions:

* [x] Have you added an explanation of what your changes do?
* [x] Have you lint your code locally prior to submission?

### Testing:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] All new and existing tests passed.
* [x] Have you run `rubocop` and fixed offenses?

**Test coverage** =
--------------------------------------------------------------------------------
### Change Log
Closes #21 

Updated `admin_can_delete_tutorial_spec` to test that associated videos are also deleted
Updated `Tutorial` model to have association being dependent and destroying videos 
Updated `admin/dashboard/show` view to have an id tag on each tutorial for testing
 